### PR TITLE
added equality test for NaN values

### DIFF
--- a/src/jsondiffpatch.js
+++ b/src/jsondiffpatch.js
@@ -193,6 +193,9 @@
         if (o === n) {
             return;
         }
+        if ((o !== o) && (n !== n)) {
+            return; // o and n are both NaN
+        }
         ntype = typeof n;
         otype = typeof o;
         nnull = n === null;


### PR DESCRIPTION
If both values are NaN, the normal equality check with === does not work.
