### PR TITLE
Update qunit path

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@
 if (typeof exports !== "undefined") {
     if (typeof QUnit == 'undefined' && typeof require == 'function') {
         // dirty fix for missing QUnit object on CommonJS env
-        var QUnit = require('../node_modules/qunit/support/qunit/qunit.js');
+        var QUnit = require('../node_modules/qunit/support/qunit/qunit/qunit.js');
     }
     var jsondiffpatch = require('../src/jsondiffpatch');
 
@@ -15,7 +15,7 @@ if (typeof exports !== "undefined") {
 QUnit.module('main', {
 
     setup: function(){
-    
+
         jsondiffpatch.config.objectHash = function(obj) {
             return obj.id || obj.name || JSON.stringify(obj);
         };
@@ -45,7 +45,7 @@ America was coined in 1507 by cartographers Martin Waldseemüller and Matthias \
 Ringmann, after Amerigo Vespucci, who was the first European to suggest that \
 the lands newly discovered by Europeans were not India, but a New World \
 unknown to Europeans."            ,
-            
+
             surface: 17840000,
             timezone: [-4, -2],
             demographics: {
@@ -115,85 +115,85 @@ unknown to Europeans."            ,
                 unasur: true
             }]
         };
-        
+
         sa.countries._key = 'name';
-        
+
         var ctx = this;
-        
+
         this.makeCopy = function(){
             ctx.sa2 = JSON.parse(JSON.stringify(ctx.sa), jsondiffpatch.dateReviver);
         };
-        
+
         this.diffPatch = function(){
             ctx.delta = jsondiffpatch.diff(this.sa, this.sa2);
             jsondiffpatch.patch(this.sa, ctx.delta);
             ctx.delta2 = jsondiffpatch.diff(this.sa, this.sa2);
         };
-        
+
         this.diffUnpatch = function(){
             ctx.delta = jsondiffpatch.diff(this.sa, this.sa2);
             jsondiffpatch.unpatch(this.sa2, ctx.delta);
             ctx.delta2 = jsondiffpatch.diff(this.sa, this.sa2);
         };
-          
+
     }
-    
+
 });
 
 
 test("change simple values", 1, function(){
 
     this.makeCopy();
-    
+
     this.sa2.name = "Sudamérica";
     this.sa2.surface += 9832;
     this.sa2.countries[0].independence = new Date(1816, 6, 19);
     this.sa2.countries[0].unasur = false;
-    
+
     this.diffPatch();
-    
+
     equal(typeof this.delta2, "undefined", 'original equals new');
 });
 
 test("change from/to undefined", 1, function(){
 
     this.makeCopy();
-    
+
     this.sa2.spanishName = "Sudamérica";
     delete this.sa2.surface;
     this.sa2.countries[0].officialName = "República Argentina";
     delete this.sa2.countries[0].unasur;
-    
+
     this.diffPatch();
-    
+
     equal(typeof this.delta2, "undefined", 'original equals new');
 });
 
 test("change from/to null", 1, function(){
 
     this.sa.oceans = null;
-    
+
     this.makeCopy();
-    
+
     this.sa2.oceans = ["Pacific", "Atlantic", "Antartic"];
     this.sa2.demographics.population = null;
-    
+
     this.diffPatch();
-    
+
     equal(typeof this.delta2, "undefined", 'original equals new');
 });
 
 test("change simple list", 2, function(){
 
     this.makeCopy();
-    
+
     this.sa2.languages[0] = "español";
     this.sa2.languages.splice(2, 3);
     this.sa2.languages.unshift("lunfardo");
     this.sa2.languages.push("italian");
-    
+
     this.diffPatch();
-    
+
     deepEqual(this.sa.languages, this.sa2.languages);
     equal(typeof this.delta2, "undefined", 'original equals new');
 });
@@ -201,28 +201,28 @@ test("change simple list", 2, function(){
 test("change subobject", 1, function(){
 
     this.makeCopy();
-    
+
     this.sa2.demographics.population += 93113;
     this.sa2.demographics.largestCities.shift();
     this.sa2.demographics.largestCities.push("Santiago");
-    
+
     this.diffPatch();
-    
+
     equal(typeof this.delta2, "undefined", 'original equals new');
 });
 
 test("change long string", 3, function(){
 
     this.makeCopy();
-    
+
     this.sa2.summary = this.sa2.summary.replace("Amerigo Vespucci", "Américo Vespucio").replace(/\[[0-9]+\]/g, '') +
     "\n\nsource: http://en.wikipedia.org/wiki/South_america\n";
-    
+
     this.diffPatch();
-    
+
     var deltaSize = JSON.stringify(this.delta).length;
     var totalSize = this.sa2.summary.length;
-    
+
     equal(JSON.stringify(this.delta).indexOf(this.sa2.summary.substr(5, 40)), -1, 'diff doesn\'t include all text');
     ok(deltaSize < totalSize, 'diff is smaller than whole string (' + Math.round(deltaSize / totalSize * 100) + '%)');
     equal(typeof this.delta2, "undefined", 'original equals new');
@@ -231,7 +231,7 @@ test("change long string", 3, function(){
 test("change list, moving items", 2, function(){
 
     this.makeCopy();
-    
+
     this.sa.countries[2].capital = "Rio de Janeiro";
     this.sa.countries[5].mercosur = true;
     this.sa.countries.pop();
@@ -245,7 +245,7 @@ test("change list, moving items", 2, function(){
     this.sa2.countries.splice(3, 0, toMove);
 
     this.diffPatch();
-    
+
     var deltaSize = JSON.stringify(this.delta).length;
     var totalSize = JSON.stringify(this.sa2.countries).length;
     ok(deltaSize < totalSize, 'diff is smaller than whole list (' + Math.round(deltaSize / totalSize * 100) + '%)');
@@ -255,18 +255,18 @@ test("change list, moving items", 2, function(){
 test("reverse diff", 1, function(){
 
     this.makeCopy();
-    
-    // change simple values    
+
+    // change simple values
     this.sa2.name = "Sudamérica";
     this.sa2.surface += 9832;
     this.sa2.countries[0].independence = new Date(1716, 6, 19);
     delete this.sa2.countries[0].unasur;
 
     this.diffPatch();
-    
+
     var deltaR = jsondiffpatch.reverse(this.delta);
 
-    var expectedDeltaR = { 
+    var expectedDeltaR = {
         name: ["Sudamérica","South America"],
         surface: [17849832,17840000],
         countries:{
@@ -284,8 +284,8 @@ test("reverse diff", 1, function(){
 test("unpatch", 1, function(){
 
     this.makeCopy();
-    
-    // change simple values    
+
+    // change simple values
     this.sa2.name = "Sudamérica";
     this.sa2.surface += 9832;
     this.sa2.countries[0].independence = new Date(1816, 6, 19);
@@ -299,7 +299,7 @@ test("unpatch", 1, function(){
     // change long text
     this.sa2.summary = this.sa2.summary.replace("Amerigo Vespucci", "Américo Vespucio").replace(/\[[0-9]+\]/g, '') +
     "\n\nsource: http://en.wikipedia.org/wiki/South_america\n";
-    
+
     // change list with key
     this.sa.countries[2].capital = "Rio de Janeiro";
     this.sa.countries[5].mercosur = true;
@@ -313,7 +313,7 @@ test("unpatch", 1, function(){
 
     this.sa2.countries._key = 'name';
 
-    this.diffUnpatch();    
+    this.diffUnpatch();
 
     equal(typeof this.delta2, "undefined", 'reversed new equals original');
 });


### PR DESCRIPTION
when doing a fresh install `npm install`  and then running `npm test`,  the command fails with this error

```
lincolnhawk:JsonDiffPatch lholmquist$ npm test

> jsondiffpatch@0.0.7 test /Users/lholmquist/develop/projects/JsonDiffPatch
> qunit -c ./src/jsondiffpatch.js -d jsondiffpatch:./src/jsondiffpatch -t ./test/test.js


Testing /Users/lholmquist/develop/projects/JsonDiffPatch/src/jsondiffpatch.js ... { [Error: Cannot find module     '../node_modules/qunit/support/qunit/qunit']
message: 'Cannot find module \'../node_modules/qunit/support/qunit/qunit\'' }
npm ERR! weird error 1
npm ERR! not ok code 0
```

Looks like the qunit folder structure has changed a little bit
