### PR TITLE
Fixed patch crash on removed objects

### DIFF
--- a/src/filters/nested.js
+++ b/src/filters/nested.js
@@ -50,9 +50,11 @@ var patchFilter = function nestedPatchFilter(context) {
     if (!context.nested) { return; }
     if (context.delta._t) { return; }
     var name, child;
-    for (name in context.delta) {
-        child = new PatchContext(context.left[name], context.delta[name]);
-        context.push(child, name);
+    if(context.left) {
+        for (name in context.delta) {
+            child = new PatchContext(context.left[name], context.delta[name]);
+            context.push(child, name);
+        }
     }
     context.exit();
 };


### PR DESCRIPTION
The `patch` method crashes when trying to patch nested object that has been removed from the target.

```
> var diff = jsondiffpatch.diff({abc:{value:1}},{abc:{value:2}})
undefined
> jsondiffpatch.patch({}, diff)
TypeError: Cannot read property 'value' of undefined
    at nestedPatchFilter (jsondiffpatch/build/bundle.js:793:46)
    at Pipe.process (jsondiffpatch/build/bundle.js:1080:9)
    at Processor.process (jsondiffpatch/build/bundle.js:1219:12)
    at DiffPatcher.patch (jsondiffpatch/build/bundle.js:208:27)
    at repl:1:16
    at REPLServer.self.eval (repl.js:110:21)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.EventEmitter.emit (events.js:95:17)
    at Interface._onLine (readline.js:202:10)
    at Interface._line (readline.js:531:8)
```
