### PR TITLE
consistently check for browser environment

### DIFF
--- a/src/formatters/index.js
+++ b/src/formatters/index.js
@@ -1,8 +1,9 @@
+var isBrowser = require('../helper').isBrowser;
 
 exports.html = require('./html');
 exports.annotated = require('./annotated');
 
-if (!process.browser) {
+if (!isBrowser()) {
 	var consoleModuleName = './console';
 	exports.console = require(consoleModuleName);
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,0 +1,8 @@
+module.exports.isBrowser = function() {
+  try {
+    // process may not be defined in browser environments
+    return process.browser;
+  } catch (e) {
+    return true;
+  }
+};

--- a/src/main-full.js
+++ b/src/main-full.js
@@ -1,5 +1,6 @@
+var isBrowser = require('./helper').isBrowser;
 
-if (process.env.browser) {
+if (isBrowser()) {
   /* global window */
   /* jshint camelcase: false */
   window.diff_match_patch = require('../public/external/diff_match_patch_uncompressed');

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+var isBrowser = require('./helper').isBrowser;
 
 var DiffPatcher = require('./diffpatcher').DiffPatcher;
 exports.DiffPatcher = DiffPatcher;
@@ -38,7 +39,7 @@ exports.reverse = function() {
 	return defaultInstance.reverse.apply(defaultInstance, arguments);
 };
 
-if (process.browser) {
+if (isBrowser()) {
 	exports.homepage = '{{package-homepage}}';
 	exports.version = '{{package-version}}';
 } else {


### PR DESCRIPTION
This PR updates the browser check to properly detect the browser
environment even if browserify does not shim the `process` variable.

This is important in setups where users include the library in projects
that skip detection of globals (speeds up builds) and aim not to include
shims (e.g. process).
