### PR TITLE
Fix left/right side mismatch in css selectors

### DIFF
--- a/public/formatters-styles/html.css
+++ b/public/formatters-styles/html.css
@@ -24,7 +24,7 @@ ul.jsondiffpatch-delta {
 }
 .jsondiffpatch-added .jsondiffpatch-property-name,
 .jsondiffpatch-added .jsondiffpatch-value pre,
-.jsondiffpatch-modified .jsondiffpatch-right-value,
+.jsondiffpatch-modified .jsondiffpatch-right-value pre,
 .jsondiffpatch-textdiff-added {
   background: #bbffbb;
 }


### PR DESCRIPTION
I noticed this when implementing in my project.  The right-side value has a background color that is taller than the left side.