### PR TITLE
HTML formatter styles override bootstrap defaults

### DIFF
--- a/public/formatters-styles/html.css
+++ b/public/formatters-styles/html.css
@@ -11,6 +11,14 @@
   margin: 0;
   padding: 0;
   display: inline-block;
+  border-radius: 0;
+  border: none;
+  color: inherit;
+  overflow: inherit;
+  background-color: inherit;
+  word-wrap: inherit;
+  word-break: inherit;
+  line-height: inherit;
 }
 ul.jsondiffpatch-delta {
   list-style-type: none;


### PR DESCRIPTION
Bootstrap modifies the default display of `pre` element (adds border styles, etc.). This makes the HTML diff really ugly. The commit tries to fix it. 

Example of how an HTML diff looks on Bootstrap site today: 
http://plnkr.co/edit/lLAmec?p=preview

Example of how a fixed HTML diff looks on Bootstrap site: 
http://plnkr.co/edit/QoW4hSTdmILtq6GAgEU4?p=preview