### PR TITLE
Remove non-literal require strings

### DIFF
--- a/src/filters/texts.js
+++ b/src/filters/texts.js
@@ -14,8 +14,7 @@ var getDiffMatchPatch = function() {
         new diff_match_patch() : new diff_match_patch.diff_match_patch();
     } else if (typeof require === 'function') {
       try {
-        var dmpModuleName = 'diff_match_patch_uncompressed';
-        var dmp = require('../../public/external/' + dmpModuleName);
+        var dmp = require('../../public/external/diff_match_patch_uncompressed');
         instance = new dmp.diff_match_patch();
       } catch (err) {
         instance = null;

--- a/src/formatters/index.js
+++ b/src/formatters/index.js
@@ -4,6 +4,5 @@ exports.html = require('./html');
 exports.annotated = require('./annotated');
 
 if (!environment.isBrowser) {
-	var consoleModuleName = './console';
-	exports.console = require(consoleModuleName);
+	exports.console = require('./console');
 }

--- a/src/main.js
+++ b/src/main.js
@@ -44,13 +44,11 @@ if (environment.isBrowser) {
 	exports.homepage = '{{package-homepage}}';
 	exports.version = '{{package-version}}';
 } else {
-	var packageInfoModuleName = '../package.json';
-	var packageInfo = require(packageInfoModuleName);
+	var packageInfo = require('../package.json');
 	exports.homepage = packageInfo.homepage;
 	exports.version = packageInfo.version;
 
-	var formatterModuleName = './formatters';
-	var formatters = require(formatterModuleName);
+	var formatters = require('./formatters');
 	exports.formatters = formatters;
 	// shortcut for console
 	exports.console = formatters.console;


### PR DESCRIPTION
Been attempting to compile a project using jsondiffpatch with EncloseJS (http://enclosejs.com/).

Requiring non-literal strings causes some issues, as the compiler can't follow the require dependency (unsure about other browserify-style systems).

Looking into the lines in question, I couldn't see why the requires were setup that way. So I've submitted a pull request with my minor changes to make Enclose (and presumedly other similar tools) happy.