### PR TITLE
Adding the option to exclude certain properties

### DIFF
--- a/src/contexts/context.js
+++ b/src/contexts/context.js
@@ -28,6 +28,10 @@ Context.prototype.switchTo = function(next, pipe) {
 };
 
 Context.prototype.push = function(child, name) {
+	if(this.options.excludeProperties && this.options.excludeProperties.indexOf(name) !== -1) {
+		return;
+	}
+	
 	child.parent = this;
 	if (typeof name !== 'undefined') {
 		child.childName = name;

--- a/src/contexts/context.js
+++ b/src/contexts/context.js
@@ -28,7 +28,7 @@ Context.prototype.switchTo = function(next, pipe) {
 };
 
 Context.prototype.push = function(child, name) {
-	if(this.options.excludeProperties && this.options.excludeProperties.indexOf(name) !== -1) {
+	if(this.options && this.options.excludeProperties && this.options.excludeProperties.indexOf(name) !== -1) {
 		return;
 	}
 	

--- a/test/examples/diffpatch.js
+++ b/test/examples/diffpatch.js
@@ -1188,6 +1188,70 @@ examples.arrays = [{
       },
       _2: ['', 7, 3]
     }
+  }, {
+    name: 'nested with movements using custom objectHash and excludeProperties',
+    options: {
+      objectHash: function(obj) {
+        if (obj && obj.item_key) {
+          return obj.item_key;
+        }
+      },
+      excludeProperties: ['width']
+    },
+    left: [1, 2, 4, {
+        item_key: 'five',
+        width: 4
+      },
+      6, 7, 8, {
+        item_key: 4,
+        width: 10,
+        height: 3
+      },
+      9, 10
+    ],
+    right: [1, 2, {
+        item_key: 4,
+        width: 12
+      },
+      4, {
+        item_key: 'five',
+        width: 4
+      },
+      6, 7, 8, 9, 10
+    ],
+    delta: {
+      _t: 'a',
+      2: {
+        height: [3, 0, 0]
+      },
+      _7: ['', 2, 3]
+    },
+    reverse: {
+      _t: 'a',
+      7: {
+        height: [3]
+      },
+      _2: ['', 7, 3]
+    },
+    patched: [ 1, 2, { 
+        item_key: 4, 
+        width: 10 
+      },
+      4, { 
+        item_key: 'five', 
+        width: 4 
+      }, 6, 7, 8, 9, 10 
+    ],
+    unpatched: [ 1, 2, 4, { 
+        item_key: 'five', 
+        width: 4 
+      },
+      6, 7, 8, { 
+        item_key: 4, 
+        width: 12,
+        height: 3
+      }, 9, 10 
+    ]
   },
   0
 ];

--- a/test/index.js
+++ b/test/index.js
@@ -171,7 +171,7 @@ describe('DiffPatcher', function() {
           });
           it('can patch', function() {
             var right = this.instance.patch(clone(example.left), example.delta);
-            expect(right).to.be.deepEqual(example.right);
+            expect(right).to.be.deepEqual(example.patched || example.right);
           });
           it('can reverse delta', function() {
             var reverse = this.instance.reverse(example.delta);
@@ -187,7 +187,7 @@ describe('DiffPatcher', function() {
           });
           it('can unpatch', function() {
             var left = this.instance.unpatch(clone(example.right), example.delta);
-            expect(left).to.be.deepEqual(example.left);
+            expect(left).to.be.deepEqual(example.unpatched || example.left);
           });
         });
       });


### PR DESCRIPTION
Our team needed to compare two very big JSONs. 

While some properties needed to be observed closely, others would be allowed to change.
In order to focus on the important properties, we implemented the option to exclude certain properties from the diff, which would be specified whenever a configured instance was created. 

We achieved that by simply preventing the to be excluded properties being pushed into the context. (See src/contexts/context.js Line 31). We would like to have some feedback if this is a reasonable approach or if this could cause unwanted side effects. 