### PR TITLE
Fix crash when using `hasOwnProperty` as a property name

### DIFF
--- a/src/filters/nested.js
+++ b/src/filters/nested.js
@@ -31,7 +31,7 @@ var objectsDiffFilter = function objectsDiffFilter(context) {
 
   var name, child, propertyFilter = context.options.propertyFilter;
   for (name in context.left) {
-    if (!context.left.hasOwnProperty(name)) {
+    if (!Object.prototype.hasOwnProperty.call(context.left, name)) {
       continue;
     }
     if (propertyFilter && !propertyFilter(name, context)) {
@@ -41,7 +41,7 @@ var objectsDiffFilter = function objectsDiffFilter(context) {
     context.push(child, name);
   }
   for (name in context.right) {
-    if (!context.right.hasOwnProperty(name)) {
+    if (!Object.prototype.hasOwnProperty.call(context.right, name)) {
       continue;
     }
     if (propertyFilter && !propertyFilter(name, context)) {
@@ -88,7 +88,7 @@ var collectChildrenPatchFilter = function collectChildrenPatchFilter(context) {
   var child;
   for (var index = 0; index < length; index++) {
     child = context.children[index];
-    if (context.left.hasOwnProperty(child.childName) && child.result === undefined) {
+    if (Object.prototype.hasOwnProperty.call(context.left, child.childName) && child.result === undefined) {
       delete context.left[child.childName];
     } else if (context.left[child.childName] !== child.result) {
       context.left[child.childName] = child.result;

--- a/src/formatters/base.js
+++ b/src/formatters/base.js
@@ -12,7 +12,7 @@ var getObjectKeys = typeof Object.keys === 'function' ?
   } : function(obj) {
     var names = [];
     for (var property in obj) {
-      if (obj.hasOwnProperty(property)) {
+      if (Object.prototype.hasOwnProperty.call(obj, property)) {
         names.push(property);
       }
     }

--- a/test/examples/diffpatch.js
+++ b/test/examples/diffpatch.js
@@ -701,6 +701,16 @@ examples.objects = [{
     reverse: {
       b: [2]
     }
+  }, {
+    name: 'hasOwnProperty',
+    /* jshint ignore:start */
+    left: {
+      hasOwnProperty: true,
+    },
+    right: {
+      hasOwnProperty: true,
+    },
+    /* jshint ignore:end */
   },
   0
 ];

--- a/test/index.js
+++ b/test/index.js
@@ -58,12 +58,12 @@ var deepEqual = function(obj1, obj2) {
     }
     var name;
     for (name in obj2) {
-      if (!obj1.hasOwnProperty(name)) {
+      if (!Object.prototype.hasOwnProperty.call(obj1, name)) {
         return false;
       }
     }
     for (name in obj1) {
-      if (!obj2.hasOwnProperty(name) || !deepEqual(obj1[name], obj2[name])) {
+      if (!Object.prototype.hasOwnProperty.call(obj2, name) || !deepEqual(obj1[name], obj2[name])) {
         return false;
       }
     }
@@ -120,7 +120,7 @@ var objectKeys = (typeof Object.keys === 'function') ?
   function(obj) {
     var keys = [];
     for (var key in obj) {
-      if (obj.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
         keys.push(key);
       }
     }


### PR DESCRIPTION
When object has 'hasOwnProperty' as a property name, jsondiffpatch crashes.

```javascript
'use strict';
var jsondiffpatch = require('jsondiffpatch');

var a = {
  hasOwnProperty: 1,
};

var b = {
  hasOwnProperty: 2,
};

console.log(jsondiffpatch.diff(a, b));
```

```
❯ node -v
v4.3.1

❯ node foo.js

/private/tmp/foo/node_modules/jsondiffpatch/src/filters/nested.js:34
    if (!context.left.hasOwnProperty(name)) {
                      ^

TypeError: context.left.hasOwnProperty is not a function
    at objectsDiffFilter (/private/tmp/foo/node_modules/jsondiffpatch/src/filters/nested.js:34:23)
    at Pipe.process (/private/tmp/foo/node_modules/jsondiffpatch/src/pipe.js:18:5)
    at Processor.process (/private/tmp/foo/node_modules/jsondiffpatch/src/processor.js:46:14)
    at DiffPatcher.diff (/private/tmp/foo/node_modules/jsondiffpatch/src/diffpatcher.js:46:25)
    at Object.exports.diff (/private/tmp/foo/node_modules/jsondiffpatch/src/main.js:19:31)
    at Object.<anonymous> (/private/tmp/foo/foo.js:12:27)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
```

