### PR TITLE
add array option to specify all moves explicitly

### DIFF
--- a/src/filters/arrays.js
+++ b/src/filters/arrays.js
@@ -99,7 +99,7 @@ var explicitDiffFilter = function explicitDiffFilter (context) {
   var match;
 
   var removedItems = [];
-  var addedItems = []
+  var addedItems = [];
 
   if (len1 > 0 && len2 > 0 && !matchContext.objectHash &&
     typeof matchContext.matchByPosition !== 'boolean') {
@@ -107,7 +107,7 @@ var explicitDiffFilter = function explicitDiffFilter (context) {
   }
 
   while (index < len1 || index < len2) {
-    match = matchItems(array1, array2, index, index, matchContext)
+    match = matchItems(array1, array2, index, index, matchContext);
     if (match) {
       child = new DiffContext(context.left[index], context.right[index]);
       context.push(child, index);
@@ -116,14 +116,14 @@ var explicitDiffFilter = function explicitDiffFilter (context) {
         removedItems.push({
           item : array1[index],
           index: index,
-        })  
+        });
       }
       
       if (index < len2) {
         addedItems.push({
           item: array2[index],
           index: index,
-        })  
+        });
       }
       
     }
@@ -131,7 +131,7 @@ var explicitDiffFilter = function explicitDiffFilter (context) {
     index++;
   }
 
-  if (removedItems.length == 0 && addedItems.length == 0) {
+  if (removedItems.length === 0 && addedItems.length === 0) {
     context.setResult(undefined).exit();
     return;
   }
@@ -192,11 +192,11 @@ var explicitDiffFilter = function explicitDiffFilter (context) {
     if (addedItem.isMove) {
       continue;
     }
-    result[addedItem.index] = [addedItem.item]
+    result[addedItem.index] = [addedItem.item];
   }
 
   context.setResult(result).exit();
-}
+};
 
 var diffFilter = function arraysDiffFilter(context) {
   if (!context.leftIsArray) {

--- a/test/examples/diffpatch.js
+++ b/test/examples/diffpatch.js
@@ -779,6 +779,54 @@ examples.arrays = [{
     },
     exactReverse: false
   }, {
+    name: 'explicit movements',
+    options : {
+      arrays : {
+        explicitMove : true
+      }
+    },
+    left: [1, 2, 3, 4],
+    right: [2, 4, 1, 3],
+    delta: {
+      _t: 'a',
+      _0: ['', 2, 3],
+      _1: ['', 0, 3],
+      _2: ['', 3, 3],
+      _3: ['', 1, 3]
+    },
+    reverse: {
+      _t: 'a',
+      _2: ['', 0, 3],
+      _0: ['', 1, 3],
+      _3: ['', 2, 3],
+      _1: ['', 3, 3]
+    }
+  }, {
+    name: 'explicit movements on insert',
+    options : {
+      arrays : {
+        explicitMove : true
+      }
+    },
+    left: [1, 2, 3, 4],
+    right: [0, 1, 2, 3, 4],
+    delta: {
+      _t: 'a',
+      0: [0],
+      _0: ['', 1, 3],
+      _1: ['', 2, 3],
+      _2: ['', 3, 3],
+      _3: ['', 4, 3]
+    },
+    reverse: {
+      _t: 'a',
+      _0: [0, 0, 0],
+      _1: ['', 0, 3],
+      _2: ['', 1, 3],
+      _3: ['', 2, 3],
+      _4: ['', 3, 3]
+    }
+  }, {
     name: 'nested',
     options: {
       objectHash: function(obj) {
@@ -818,6 +866,45 @@ examples.arrays = [{
       2: {
         width: [12, 10]
       }
+    }
+  }, {
+    name: 'nested with explicit movement',
+    options: {
+      objectHash: function(obj) {
+        if (obj && obj.id) {
+          return obj.id;
+        }
+      },
+      arrays : {
+        explicitMove : true
+      }
+    },
+    left: [1, 2, {
+      id: 'three',
+      width: 4
+    },
+    4
+    ],
+    right: [1, 2, 4, {
+      id: 'three',
+      width: 5
+    },
+    ],
+    delta: {
+      _t: 'a',
+      3 : {
+        'width':[4,5]
+      },
+      _2 : ['', 3, 3],
+      _3 : ['', 2, 3],
+    },
+    reverse: {
+      _t: 'a',
+      2 : {
+        'width':[5,4]
+      },
+      _2 : ['', 3, 3],
+      _3 : ['', 2, 3],
     }
   }, {
     name: 'nested with movement',


### PR DESCRIPTION
I have added an array option: context.options.arrays.explicitMove

When enabled, the longest common sequence is not used, instead all resulting moves of i.e. an insert is explicitly stated.

This makes deltas easier to understand, at the price of them being bigger on inserts/deletes in the beginning of an array.
