### PR TITLE
Fixed browser environment detection inside Web Workers

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -1,2 +1,1 @@
-
-exports.isBrowser = typeof window !== 'undefined';
+exports.isBrowser = process.browser;


### PR DESCRIPTION
I moved some browserified code which uses `jsondiffpatch` into a Web Worker, but then ran into errors. After investigating, I found that `jsondiffpatch` detects browser environments using a simple check: `typeof window !== 'undefined'`. This works fine inside normal windows, but fails inside of Web Workers, where there is no `window` object. This PR switches to using the `process.browser` property which gets set by browserify/webpack/etc.

The tests this repo pass in node, but when it gets to the browser tests, it seems there is an issue with `fiberglass`:

```
[15:00:42] Starting 'bundle-jsondiffpatch'...
[15:00:42] 'bundle-jsondiffpatch' errored after 126 ms
[15:00:42] Error: Minifyify: opts.output is required since no callback was given
    at Browserify.bundle.bundle (/Users/mappum/Projects/jsondiffpatch/node_modules/minifyify/lib/index.js:55:13)
    at createBundle (/Users/mappum/Projects/jsondiffpatch/node_modules/fiberglass/src/gulp/tasks/util/bundler.js:108:30)
    at bundlify (/Users/mappum/Projects/jsondiffpatch/node_modules/fiberglass/src/gulp/tasks/util/bundler.js:160:14)
    at Gulp.bundleTask (/Users/mappum/Projects/jsondiffpatch/node_modules/fiberglass/src/gulp/tasks/util/bundler.js:171:5)
    at module.exports (/Users/mappum/Projects/jsondiffpatch/node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (/Users/mappum/Projects/jsondiffpatch/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (/Users/mappum/Projects/jsondiffpatch/node_modules/orchestrator/index.js:214:10)
    at /Users/mappum/Projects/jsondiffpatch/node_modules/orchestrator/index.js:279:18
    at finish (/Users/mappum/Projects/jsondiffpatch/node_modules/orchestrator/lib/runTask.js:21:8)
    at cb (/Users/mappum/Projects/jsondiffpatch/node_modules/orchestrator/lib/runTask.js:29:3)
    at CB (/Users/mappum/Projects/jsondiffpatch/node_modules/rimraf/rimraf.js:68:5)
    at /Users/mappum/Projects/jsondiffpatch/node_modules/rimraf/rimraf.js:91:16
    at FSReqWrap.oncomplete (fs.js:123:15)
npm ERR! Test failed.  See above for more details.
```
