### PR TITLE
Add Pipe remove/replace methods and document them

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -94,3 +94,16 @@ To complete the plugin, let's add the reverse filter, so numeric deltas can be r
   assertSame(right, { population: 400 });
 ```
 
+Pipe API
+------
+
+The following methods are offered to manipulate filters in a pipe.
+
+- `append(filter1, filter2, ...)` - Append one or more filters to the existing list
+- `prepend(filter1, filter2, ...)` - Prepend one or more filters to the existing list
+- `after(filterName, filter1, filter2, ...)` - Add one ore more filters after the specified filter
+- `before(filterName, filter1, filter2, ...)` - Add one ore more filters before the specified filter
+- `replace(filterName, filter1, filter2, ...)` - Replace the specified filter with one ore more filters
+- `remove(filterName)` - Remove the filter with the specified name
+- `clear()` - Remove all filters from this pipe
+- `list()` - Return array of ordered filter names for this pipe

--- a/src/pipe.js
+++ b/src/pipe.js
@@ -84,6 +84,23 @@ Pipe.prototype.before = function(filterName) {
   return this;
 };
 
+Pipe.prototype.replace = function(filterName) {
+  var index = this.indexOf(filterName);
+  var params = Array.prototype.slice.call(arguments, 1);
+  if (!params.length) {
+    throw new Error('a filter is required');
+  }
+  params.unshift(index, 1);
+  Array.prototype.splice.apply(this.filters, params);
+  return this;
+};
+
+Pipe.prototype.remove = function(filterName) {
+  var index = this.indexOf(filterName);
+  this.filters.splice(index, 1);
+  return this;
+};
+
 Pipe.prototype.clear = function() {
   this.filters.length = 0;
   return this;

--- a/test/index.js
+++ b/test/index.js
@@ -334,6 +334,32 @@ describe('DiffPatcher', function() {
 
     });
 
+    describe('removing and replacing pipe filters', function(){
+      it('removes specified filter', function(){
+        expect(this.instance.processor.pipes.diff.list()).to.be.deepEqual([
+          'collectChildren', 'numeric', 'trivial', 'dates', 'texts', 'objects', 'arrays'
+        ]);
+        this.instance.processor.pipes.diff.remove('dates');
+        expect(this.instance.processor.pipes.diff.list()).to.be.deepEqual([
+          'collectChildren', 'numeric', 'trivial', 'texts', 'objects', 'arrays'
+        ]);
+      });
+
+      it('replaces specified filter', function(){
+        function fooFilter(context) {
+          context.setResult(['foo']).exit();
+        }
+        fooFilter.filterName = 'foo';
+        expect(this.instance.processor.pipes.diff.list()).to.be.deepEqual([
+          'collectChildren', 'numeric', 'trivial', 'texts', 'objects', 'arrays'
+        ]);
+        this.instance.processor.pipes.diff.replace('trivial', fooFilter);
+        expect(this.instance.processor.pipes.diff.list()).to.be.deepEqual([
+          'collectChildren', 'numeric', 'foo', 'texts', 'objects', 'arrays'
+        ]);
+      });
+    });
+
   });
 
   describe('formatters', function () {


### PR DESCRIPTION
I'm creating a plugin ([schnerd/jsondiffpatch-arrays-by-hash](https://github.com/)) and would love to have these pipe methods to manipulate the pipes array when adding my plugin.

- `replace(filterName, filter1, filter2, ...)` - Replace the specified filter with one ore more filters
- `remove(filterName)` - Remove the filter with the specified name

Thoughts?