### PR TITLE
Fix #216

### DIFF
--- a/src/formatters/html.js
+++ b/src/formatters/html.js
@@ -28,11 +28,11 @@ class HtmlFormatter extends BaseFormatter {
         pieceIndex < piecesLength;
         pieceIndex++
       ) {
-        /* global unescape */
+        /* global decodeURI */
         let piece = pieces[pieceIndex];
         context.out(
           `<span class="jsondiffpatch-textdiff-${piece.type}">${htmlEscape(
-            unescape(piece.text)
+            decodeURI(piece.text)
           )}</span>`
         );
       }

--- a/test/index.js
+++ b/test/index.js
@@ -483,5 +483,103 @@ describe('DiffPatcher', () => {
         expectFormat([1, 2], [2, 1], [{op: 'move', from: '/1', path: '/0'}]);
       });
     });
+    
+    describe('html', () => {
+      let instance;
+      let formatter;
+
+      before(() => {
+        instance = new DiffPatcher({ textDiff: { minLength: 10 } });
+        formatter = jsondiffpatch.formatters.html;
+      });
+
+      const expectFormat = (before, after, expected) => {
+        const diff = instance.diff(before, after);
+        const format = formatter.format(diff);
+        expect(format).to.be.eql(expected);
+      };
+
+      const expectedHtml = (expectedDiff) => {
+        let html = []
+        arrayForEach(expectedDiff, function(diff) {
+          html.push('<li>');
+          html.push('<div class="jsondiffpatch-textdiff-location">');
+          html.push(`<span class="jsondiffpatch-textdiff-line-number">${diff.start}</span>`);
+          html.push(`<span class="jsondiffpatch-textdiff-char">${diff.length}</span>`);
+          html.push('</div>');
+          html.push('<div class="jsondiffpatch-textdiff-line">');
+
+          arrayForEach(diff.data, function(data) {
+            html.push(`<span class="jsondiffpatch-textdiff-${data.type}">${data.text}</span>`);
+          });
+
+          html.push('</div>');
+          html.push('</li>');
+        });
+        return `<div class="jsondiffpatch-delta jsondiffpatch-textdiff"><div class="jsondiffpatch-value"><ul class="jsondiffpatch-textdiff">${html.join('')}</ul></div></div>`;
+      }
+
+      it('should format Chinese', () => {
+        const before = '喵星人最可爱最可爱最可爱喵星人最可爱最可爱最可爱';
+        const after = '汪星人最可爱最可爱最可爱喵星人meow最可爱最可爱最可爱';
+        const expectedDiff = [{
+          start: 1,
+          length: 17,
+          data: [{
+            type: 'deleted',
+            text: '喵'
+          }, {
+            type: 'added',
+            text: '汪'
+          }, {
+            type: 'context',
+            text: '星人最可爱最可爱最可爱喵星人最可'
+          }]
+        }, {
+          start: 8,
+          length: 16,
+          data: [{
+            type: 'context',
+            text: '可爱最可爱喵星人'
+          }, {
+            type: 'added',
+            text: 'meow'
+          }, {
+            type: 'context',
+            text: '最可爱最可爱最可'
+          }]
+        }];
+        expectFormat(before, after, expectedHtml(expectedDiff));
+      });
+
+      it('should format Japanese', () => {
+        const before = '猫が可愛いです猫が可愛いです';
+        const after = '猫がmeow可愛いですいぬ可愛いです';
+        const expectedDiff = [{
+          start: 1,
+          length: 13,
+          data: [{
+            type: 'context',
+            text: '猫が'
+          }, {
+            type: 'added',
+            text: 'meow'
+          }, {
+            type: 'context',
+            text: '可愛いです'
+          }, {
+            type: 'deleted',
+            text: '猫が'
+          }, {
+            type: 'added',
+            text: 'いぬ'
+          }, {
+            type: 'context',
+            text: '可愛いで'
+          }]
+        }];
+        expectFormat(before, after, expectedHtml(expectedDiff));
+      });
+    });
   });
 });


### PR DESCRIPTION
Replace `unescape` with `decodeURI` on the html formatter.
Add two test case including Chinese and Japanese.