### PR TITLE
Fix wrong import path in CLI

### DIFF
--- a/bin/jsondiffpatch
+++ b/bin/jsondiffpatch
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const jsondiffpatch = require('../build/jsondiffpatch.cjs');
+const jsondiffpatch = require('..');
 
 const fs = require('fs');
 


### PR DESCRIPTION
CLI seems to have been broken by db03af393994d570f15680e91bc46dfb0c04ea82.

Instead of requiring the module by path, this just imports the main module.