### PR TITLE
Fix UMD builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "rollup": "^0.54.1",
     "rollup-plugin-babel": "^3.0.3",
     "rollup-plugin-commonjs": "^8.2.6",
+    "rollup-plugin-hypothetical": "^2.1.0",
     "rollup-plugin-istanbul": "^2.0.0",
     "rollup-plugin-node-resolve": "^3.0.2",
     "rollup-plugin-replace": "^2.0.0",

--- a/rollup-config-factory.js
+++ b/rollup-config-factory.js
@@ -6,11 +6,12 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import babel from 'rollup-plugin-babel';
 import istanbul from 'rollup-plugin-istanbul';
+import hypothetical from 'rollup-plugin-hypothetical';
 import pkg from './package.json';
 import Visualizer from 'rollup-plugin-visualizer';
 
 /**
- * browser-friendly UMD build
+ * browser-friendly UMD build (No chalk)
  * @param {string} dirName Output destination directory
  */
 export function createBrowserUmdBuildConfig(dirName = 'dist') {
@@ -18,7 +19,7 @@ export function createBrowserUmdBuildConfig(dirName = 'dist') {
     input: 'src/main.js',
     external: [
       // external node modules
-      'chalk',
+      // 'chalk',
       // 'diff-match-patch'
     ],
     output: {
@@ -28,6 +29,15 @@ export function createBrowserUmdBuildConfig(dirName = 'dist') {
     },
     plugins: [
       replace({ 'process.browser': true }),
+      hypothetical({
+        allowRealFiles: true,
+        allowFallthrough: true,
+        files: {
+          './node_modules/chalk/index.js': `
+        export default null;
+      `,
+        },
+      }),
       babel({
         exclude: 'node_modules/**',
         plugins: ['external-helpers'],
@@ -47,8 +57,8 @@ export function createSlimBrowserUmdBuildConfig(dirName = 'dist') {
     input: 'src/main.js',
     external: [
       // external node modules
-      'chalk',
-      'diff-match-patch',
+      // 'chalk',
+      // 'diff-match-patch',
     ],
     output: {
       name: pkg.name,
@@ -64,6 +74,18 @@ export function createSlimBrowserUmdBuildConfig(dirName = 'dist') {
           .replace(/^dist\//, `${dirName}/`),
       }),
       replace({ 'process.browser': true }),
+      hypothetical({
+        allowRealFiles: true,
+        allowFallthrough: true,
+        files: {
+          './node_modules/chalk/index.js': `
+        export default null;
+      `,
+          './node_modules/diff-match-patch/index.js': `
+        export default null;
+      `,
+        },
+      }),
       babel({
         exclude: 'node_modules/**',
         plugins: ['external-helpers'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,6 +3604,10 @@ rollup-plugin-commonjs@^8.2.6:
     resolve "^1.4.0"
     rollup-pluginutils "^2.0.1"
 
+rollup-plugin-hypothetical@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-hypothetical/-/rollup-plugin-hypothetical-2.1.0.tgz#7fec9a865ed7d0eac14ca6ee2b2c4088acdb1955"
+
 rollup-plugin-istanbul@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-istanbul/-/rollup-plugin-istanbul-2.0.0.tgz#47a2d7eaf27297fe3c5f36b1decd70791ae8b026"


### PR DESCRIPTION
# Current state
With the current UMD builds, external modules where still required. If they were importer in an HTML page, the require("...") calls would fail and fallback to default values. 

# Problem

When developing an browser application with another bundler, it will bundle external dependencies from the "node_modules" folder.

# Proposal

I added a new devDependency which is [rollup-plugin-hypothetical](https://github.com/Permutatrix/rollup-plugin-hypothetical). This new plugin allows us to map sources files to import statements.

In our case, I mapped external dependencies to null function.

# Related issue

#220 