### PR TITLE
Add clone option to patch context

### DIFF
--- a/src/contexts/patch.js
+++ b/src/contexts/patch.js
@@ -1,4 +1,5 @@
 import Context from './context';
+import defaultClone from '../clone';
 
 class PatchContext extends Context {
   constructor(left, delta) {
@@ -6,6 +7,22 @@ class PatchContext extends Context {
     this.left = left;
     this.delta = delta;
     this.pipe = 'patch';
+  }
+
+  setResult(result) {
+    if (this.options.cloneDiffValues && typeof result === 'object') {
+      const clone =
+        typeof this.options.cloneDiffValues === 'function'
+          ? this.options.cloneDiffValues
+          : defaultClone;
+      if (typeof result[0] === 'object') {
+        result[0] = clone(result[0]);
+      }
+      if (typeof result[1] === 'object') {
+        result[1] = clone(result[1]);
+      }
+    }
+    return Context.prototype.setResult.apply(this, arguments);
   }
 }
 


### PR DESCRIPTION
Hey thanks for a great project.

I noticed when using this that the cloneDiffValues option was not respected in a patch context so I added the same setResult function as in a diff context.

/cc @arnihermann @logason