### PR TITLE
Allow user to specify a maxLength for character diffing

### DIFF
--- a/src/filters/texts.js
+++ b/src/filters/texts.js
@@ -69,6 +69,16 @@ export const diffFilter = function textsDiffFilter(context) {
     context.setResult([context.left, context.right]).exit();
     return;
   }
+  
+  // if the user specified a max length for character diffing, don't use the text-diff algorithm
+  let maxLength = (context.options &&
+      context.options.textDiff &&
+      context.options.textDiff.maxLength);
+  if (maxLength && (context.left.length > maxLength || context.right.length > maxLength)) {
+    context.setResult([context.left, context.right]).exit();
+    return;
+  }
+  
   // large text, try to use a text-diff algorithm
   let diffMatchPatch = getDiffMatchPatch();
   if (!diffMatchPatch) {

--- a/src/filters/texts.js
+++ b/src/filters/texts.js
@@ -73,8 +73,8 @@ export const diffFilter = function textsDiffFilter(context) {
   // if the user specified a max length for character diffing, don't use the text-diff algorithm
   let maxLength = (context.options &&
       context.options.textDiff &&
-      context.options.textDiff.maxLength);
-  if (maxLength && (context.left.length > maxLength || context.right.length > maxLength)) {
+      context.options.textDiff.maxLength) || Number.POSITIVE_INFINITY;
+  if (context.left.length > maxLength || context.right.length > maxLength) {
     context.setResult([context.left, context.right]).exit();
     return;
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,6 +24,8 @@ export interface Config {
     textDiff?: {
         // default 60, minimum string length (left and right sides) to use text diff algorythm: google-diff-match-patch
         minLength: number,
+        // optional character max (left and right sides) at which google-diff-match-patch will not be used
+        maxLength?: number,
     };
     /*
         this optional function can be specified to ignore object properties (eg. volatile data)


### PR DESCRIPTION
Users have reported inaccurate results from character diffing with very long strings, e.g. https://github.com/benjamine/jsondiffpatch/issues/248. This change would allow users to specify a max length for character diffing.