### PR TITLE
Add undefined to 'patch()' typing

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -46,7 +46,7 @@ export class DiffPatcher {
 
     clone: (value: any) => any;
     diff: (left: any, right: any) => Delta | undefined;
-    patch: (left: any, delta: Delta) => any;
+    patch: (left: any, delta: Delta | undefined) => any;
     reverse: (delta: Delta) => Delta | undefined;
     unpatch: (right: any, delta: Delta) => any;
 }


### PR DESCRIPTION
This is necessary for TypeScript's --strictNullChecks mode, otherwise the result of `diff()` (which correctly is `Delta | undefined`) cannot be provided as input for `patch()` because before this PR it only accepts the `Delta` type (without `undefined`).

The corresponding JS: https://github.com/benjamine/jsondiffpatch/blob/0c4323e9bff23ae231f4bff231ceed4df2b48be5/src/filters/trivial.js#L64-L66

----

An alternative would be to include `undefined` to the `Delta` type itself, iff all operations with a Delta input can cope with an `undefined` input (which I didn't check).