### PR TITLE
add methods for  hiding and showing unchanged fields to types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,6 +2,11 @@ export interface Formatter {
   format(delta: Delta, original: any): string;
 }
 
+export interface HTMLFormatter extends Formatter {
+    showUnchanged(): void;
+    hideUnchanged(): void;
+}
+
 export interface Delta {
     [key: string]: any;
     [key: number]: any;
@@ -54,7 +59,7 @@ export class DiffPatcher {
 export const formatters: {
   annotated: Formatter;
   console: Formatter;
-  html: Formatter;
+  html: HTMLFormatter;
 };
 
 export const console: Formatter


### PR DESCRIPTION
I use TypeScript and Angular in my project and I observed that ts compiler shows me an error when I am trying to call showUnchanged() and hideUnchanged() methods on html formatter object.

This PR should fix that.