### PR TITLE
README - show .create with default options - jsondiffpatch.create({})

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ Options
 -------
 
 ``` javascript
+// to use default options, you must pass {}
+var jsondiffpatch = require('jsondiffpatch').create({})
+// to override options:
 var jsondiffpatch = require('jsondiffpatch').create({
     // used to match objects when diffing arrays, by default only === operator is used
     objectHash: function(obj) {


### PR DESCRIPTION
If you do `jsondiffpatch.create()` (with no options argument), you get a confusing error: `TypeError: Cannot read property 'processor' of undefined`. This doesn't indicate the problem that `create` expects an empty options object, {}. Instead of adding handling or an error, for that case, I think the README is a fine solution.

README should mention this. jsondiffpatch does have sane defaults already, except for this one pesky case.

Resolves #266