### PR TITLE
fix(docs): corrects several typos in project documentation

### DIFF
--- a/docs/arrays.md
+++ b/docs/arrays.md
@@ -61,7 +61,7 @@ moves are detected by default, you can turn move detection off with:
 {
   "_originalIndex": // this is the item original position in the array
   [
-    '', // the moved item value, supressed by default
+    '', // the moved item value, suppressed by default
     destinationIndex, // this is the item final position in the array
     3 // magic number to indicate: array move
   ]

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3,12 +3,12 @@ Plugins
 
 ```diff()```, ```patch()``` and ```reverse()``` functions are implemented using a pipes &filters pattern, making them extremely customizable by adding or replacing filters.
 
-Some examples of what you can acheive writing your own filter:
+Some examples of what you can achieve writing your own filter:
 - diff special custom objects (eg. DOM nodes, native objects, functions, RegExp, node.js streams?)
 - ignore parts of the graph using any custom rule (type, path, flags)
 - change diff strategy in specific parts of the graph, eg. rely on change tracking info for Knockout.js tracked objects
 - implement custom diff mechanisms, like relative numeric deltas
-- suprise me! :)
+- surprise me! :)
 
 Check the ```/src/filters``` folder for filter examples.
 


### PR DESCRIPTION
Scope of changes is restricted to docs only.