### PR TITLE
Add option to opt out of text diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,10 @@ var jsondiffpatch = require('jsondiffpatch').create({
         includeValueOnMove: false
     },
     textDiff: {
-        // default 60, minimum string length (left and right sides) to use text diff algorythm: google-diff-match-patch
+        // default 60, minimum string length (left and right sides) to use text diff algorithm: google-diff-match-patch
         minLength: 60
+        // default true, set to false to completely opt out of text diffing
+        enabled: true,
     },
     propertyFilter: function(name, context) {
       /*

--- a/docs/deltas.md
+++ b/docs/deltas.md
@@ -86,7 +86,7 @@ an item was moved to a different position in the same array
 ``` javascript
 delta = [ '', destinationIndex, 3]
 ```
-> Note: '' represents the moved item value, suppresed by default
+> Note: '' represents the moved item value, suppressed by default
 
 > Note: 3 is the magical number that indicates "array move"
 
@@ -118,3 +118,11 @@ delta = [ unidiff, 0, 2 ]
 
 > Note: unidiff is actually a character-based variation of Unidiff format that is explained [here](https://code.google.com/p/google-diff-match-patch/wiki/Unidiff)
 
+You can completely opt out of text diffing:
+``` javascript
+var customDiffPatch = jsondiffpatch.create({
+  textDiff: {
+    enabled: false // default true
+  }
+});
+```

--- a/src/filters/texts.js
+++ b/src/filters/texts.js
@@ -60,6 +60,17 @@ export const diffFilter = function textsDiffFilter(context) {
   if (context.leftType !== 'string') {
     return;
   }
+
+  // opt out of text diffing
+  let enabled =
+    (context.options &&
+      context.options.textDiff &&
+      context.options.textDiff.enabled)
+  if (enabled === false) {
+    context.setResult([context.left, context.right]).exit();
+    return;
+  }
+
   let minLength =
     (context.options &&
       context.options.textDiff &&
@@ -69,6 +80,7 @@ export const diffFilter = function textsDiffFilter(context) {
     context.setResult([context.left, context.right]).exit();
     return;
   }
+
   // large text, try to use a text-diff algorithm
   let diffMatchPatch = getDiffMatchPatch();
   if (!diffMatchPatch) {
@@ -77,6 +89,7 @@ export const diffFilter = function textsDiffFilter(context) {
     context.setResult([context.left, context.right]).exit();
     return;
   }
+
   let diff = diffMatchPatch.diff;
   context.setResult([diff(context.left, context.right), 0, TEXT_DIFF]).exit();
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -148,8 +148,10 @@ export interface Config {
     };
 
     textDiff?: {
-        // default 60, minimum string length (left and right sides) to use text diff algorythm: google-diff-match-patch
-        minLength: number,
+        // default 60, minimum string length (left and right sides) to use text diff algorithm: google-diff-match-patch
+        minLength?: number,
+        // default true, set to false to completely opt out of text diffing
+        enabled?: boolean,
     };
 
     /**


### PR DESCRIPTION
Using a new option rather than `minLength: -1` or similar to avoid a breaking change to the API, and to rely on explicit parameters rather than implicit behavior.