### PR TITLE
Temporarily remove prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "test": "nyc mocha",
     "watch": "nodemon --exec \"mocha\"",
     "prepack": "npm run build && npm run build-dist",
-    "prepublishOnly": "npm run test && npm run lint",
     "cover-report": "open coverage/lcov-report/index.html",
     "cover-publish": "nyc mocha && codeclimate < coverage/lcov.info"
   },


### PR DESCRIPTION
npm lifecycle scripts are confusing.

`prepack` is [supposed to be used for building for deployment](https://yarnpkg.com/advanced/lifecycle-scripts#prepack-and-postpack). `prepublish` is [supposed to be used for linting/testing](https://yarnpkg.com/advanced/lifecycle-scripts#prepublish).

However jsondiffpatch requires the package to be built before testing and [there's no lifecycle script that runs after `prepack` to run tests](https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-operation-order).

So for now we'll just remove the prepublish script since testing and linting is already run in CI. Hopefully in the future we can run tests against the source files without needing to build first.