### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/demos/console-demo/package.json
+++ b/demos/console-demo/package.json
@@ -7,7 +7,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "jsondiffpatch": "^0.5.0"
+    "jsondiffpatch": "^0.6.0"
   },
   "devDependencies": {
     "typescript": "~5.3.2"

--- a/demos/html-demo/package.json
+++ b/demos/html-demo/package.json
@@ -6,7 +6,7 @@
     "build": "tsc && esbuild demo.ts --bundle --outdir=build"
   },
   "dependencies": {
-    "jsondiffpatch": "^0.5.0"
+    "jsondiffpatch": "^0.6.0"
   },
   "devDependencies": {
     "esbuild": "^0.19.8",

--- a/demos/numeric-plugin-demo/package.json
+++ b/demos/numeric-plugin-demo/package.json
@@ -7,7 +7,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "jsondiffpatch": "^0.5.0"
+    "jsondiffpatch": "^0.6.0"
   },
   "devDependencies": {
     "typescript": "~5.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
     "demos/console-demo": {
       "version": "1.0.0",
       "dependencies": {
-        "jsondiffpatch": "^0.5.0"
+        "jsondiffpatch": "^0.6.0"
       },
       "devDependencies": {
         "typescript": "~5.3.2"
@@ -27,7 +27,7 @@
     "demos/html-demo": {
       "version": "1.0.0",
       "dependencies": {
-        "jsondiffpatch": "^0.5.0"
+        "jsondiffpatch": "^0.6.0"
       },
       "devDependencies": {
         "esbuild": "^0.19.8",
@@ -37,7 +37,7 @@
     "demos/numeric-plugin-demo": {
       "version": "1.0.0",
       "dependencies": {
-        "jsondiffpatch": "^0.5.0"
+        "jsondiffpatch": "^0.6.0"
       },
       "devDependencies": {
         "typescript": "~5.3.2"
@@ -6327,7 +6327,7 @@
       }
     },
     "packages/jsondiffpatch": {
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@types/diff-match-patch": "^1.0.36",
@@ -6335,7 +6335,7 @@
         "diff-match-patch": "^1.0.5"
       },
       "bin": {
-        "jsondiffpatch": "bin/jsondiffpatch"
+        "jsondiffpatch": "bin/jsondiffpatch.js"
       },
       "devDependencies": {
         "@types/jest": "^29.5.10",

--- a/packages/jsondiffpatch/package.json
+++ b/packages/jsondiffpatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsondiffpatch",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "Benjamin Eidelman <beneidel@gmail.com>",
   "description": "Diff & Patch for Javascript objects",
   "contributors": [


### PR DESCRIPTION
# Draft Release Notes

## Breaking changes

- This package is now pure ESM. For more info, please read [Sindre Sorhus's FAQ](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) (#350).
- Supported Node versions are `^18.0.0 || >=20.0.0` (#350).
- Requires ES6 support (#350).
- There is no longer a default export. Import this package by using `import * as jsondiffpatch from 'jsondiffpatch'` or by importing individual methods (#350).
- Formatters are no longer exported from the main entry-point and must be imported from subpaths (#350):
  - `import * as annotatedFormatter from 'jsondiffpatch/formatters/annotated'`
  - `import * as baseFormatter from 'jsondiffpatch/formatters/base'`
  - `import * as consoleFormatter from 'jsondiffpatch/formatters/console'`
  - `import * as htmlFormatter from 'jsondiffpatch/formatters/html'`
  - `import * as jsonpatchFormatter from 'jsondiffpatch/formatters/jsonpatch'`
- Updated CSS imports (#350):
  - `import 'jsondiffpatch/formatters/styles/html.css'`
  - `import 'jsondiffpatch/formatters/styles/annotated.css'`
- The main entry-point no longer includes text diffing by default. Either pass in the diff-match-patch library via the `textDiff.diffMatchPatch` option, or use the `jsondiffpatch/with-text-diffs` entry point that is included for convenience (#352).
- `Context.switchTo()` has been removed (#345).
- `BaseFormatter.typeFormattterErrorFormatter()` now throws an error instead of returning a `string` (#345).

## Other changes
* Fix demo link in formatters doc by @johnrees in https://github.com/benjamine/jsondiffpatch/pull/311
* Fix the live demo link in the deltas docs by @Xheldon in https://github.com/benjamine/jsondiffpatch/pull/317
* Fix typos in project documentation by @plan-do-break-fix in https://github.com/benjamine/jsondiffpatch/pull/305
* Fix examples in documentation by @dayures in https://github.com/benjamine/jsondiffpatch/pull/308
* Update TS type file to include jsonpatch formatter by @thilinatnt in https://github.com/benjamine/jsondiffpatch/pull/310
* Fix incorrect matrix initialization by @rexxars in https://github.com/benjamine/jsondiffpatch/pull/291
* Documentation instances distinction by @piomar123 in https://github.com/benjamine/jsondiffpatch/pull/129
* Replace usages of `substr` with `substring` by @Methuselah96 in https://github.com/benjamine/jsondiffpatch/pull/343
* Remove dead branches by @Methuselah96 in https://github.com/benjamine/jsondiffpatch/pull/344
* Convert to TypeScript by @Methuselah96 in https://github.com/benjamine/jsondiffpatch/pull/345
* Convert tests to TypeScript by @Methuselah96 in https://github.com/benjamine/jsondiffpatch/pull/346
* Convert to monorepo and revamp build system by @Methuselah96 in https://github.com/benjamine/jsondiffpatch/pull/350
* Disable text diffs by default by @Methuselah96 in https://github.com/benjamine/jsondiffpatch/pull/352

## New Contributors
* @johnrees made their first contribution in https://github.com/benjamine/jsondiffpatch/pull/311
* @Xheldon made their first contribution in https://github.com/benjamine/jsondiffpatch/pull/317
* @plan-do-break-fix made their first contribution in https://github.com/benjamine/jsondiffpatch/pull/305
* @dayures made their first contribution in https://github.com/benjamine/jsondiffpatch/pull/308
* @thilinatnt made their first contribution in https://github.com/benjamine/jsondiffpatch/pull/310
* @rexxars made their first contribution in https://github.com/benjamine/jsondiffpatch/pull/291
* @piomar123 made their first contribution in https://github.com/benjamine/jsondiffpatch/pull/129

**Full Changelog**: https://github.com/benjamine/jsondiffpatch/compare/v0.5.0...v0.6.0
