### PR TITLE
Fix live demo

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    branches: ['master']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -17,7 +17,7 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: 'pages'
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,5 +1,4 @@
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+name: Deploy to GitHub Pages
 
 on:
   # Runs on pushes targeting the default branch
@@ -43,13 +42,10 @@ jobs:
       - name: Build HTML demo
         run: npm run build
         working-directory: ./demos/html-demo
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./demos/html-demo/
-          destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./demos/html-demo
 
   # Deployment job
   deploy:

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,51 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -30,10 +30,23 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v4
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build jsondiffpatch
+        run: npm run build
+        working-directory: ./packages/jsondiffpatch
+      - name: Build HTML demo
+        run: npm run build
+        working-directory: ./demos/html-demo
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
-          source: ./
+          source: ./demos/html-demo/
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Diff & patch JavaScript objects
 
 ---
 
-## **[Live Demo](http://benjamine.github.io/jsondiffpatch/demo/index.html)**
+## **[Live Demo](http://benjamine.github.io/jsondiffpatch/index.html)**
 
 - min+gzipped ~ 16KB
 - browser and server (ESM-only)
@@ -22,7 +22,7 @@ Diff & patch JavaScript objects
 - unpatch (eg. revert object to its original state using a delta)
 - simplistic, pure JSON, low footprint [delta format](docs/deltas.md)
 - multiple output formatters:
-  - html (check it at the [Live Demo](http://benjamine.github.io/jsondiffpatch/demo/index.html))
+  - html (check it at the [Live Demo](http://benjamine.github.io/jsondiffpatch/index.html))
   - annotated json (html), makes the JSON delta format self-explained
   - console (colored), try running `./node_modules/.bin/jsondiffpatch left.json right.json`
   - JSON Patch format RFC 6902 support
@@ -270,7 +270,7 @@ const jsondiffpatchInstance = jsondiffpatch.create({
 </html>
 ```
 
-To see formatters in action check the [Live Demo](http://benjamine.github.io/jsondiffpatch/demo/index.html).
+To see formatters in action check the [Live Demo](http://benjamine.github.io/jsondiffpatch/index.html).
 
 For more details check [Formatters documentation](docs/formatters.md)
 

--- a/docs/deltas.md
+++ b/docs/deltas.md
@@ -8,7 +8,7 @@ This format was created with a balance between readability and low footprint in 
 - to represent changed parts, arrays and magic numbers are used to keep a low footprint (i.e. you won't see verbosity like `"type": "added"`)
 - keep it pure JSON serializable
 
-A great way to understand this format is using the "Annotated JSON" option in the [Live Demo](http://benjamine.github.io/jsondiffpatch/demo/index.html), and try the different left/right examples, or edit left/right JSON to see the annotated delta update as your type.
+A great way to understand this format is using the "Annotated JSON" option in the [Live Demo](http://benjamine.github.io/jsondiffpatch/index.html), and try the different left/right examples, or edit left/right JSON to see the annotated delta update as your type.
 
 Here's a complete reference of this format.
 

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -1,6 +1,6 @@
 # Formatters
 
-Some formatters are included that let you convert a JSON delta into other formats, you can see some of these used in the [Live Demo](https://benjamine.github.io/jsondiffpatch/demo/index.html)
+Some formatters are included that let you convert a JSON delta into other formats, you can see some of these used in the [Live Demo](https://benjamine.github.io/jsondiffpatch/index.html)
 
 ## Html
 


### PR DESCRIPTION
Fixes https://github.com/benjamine/jsondiffpatch/issues/354.

I didn't realize that the the GitHub Pages demo was depending on the HTML demo being located at `./docs/demo/index.html`, which means I broke it when I moved everything around in https://github.com/benjamine/jsondiffpatch/pull/350.

Now that the HTML demo is written in TypeScript, it needs to be built before it can be deployed. This PR adds a GitHub Action to build and deploy the HTML demo to GitHub Actions and updates all the links to point the new correct address.

I tested it to make sure it worked on [a fork](https://methuselah96.github.io/jsondiffpatch/index.html).