### PR TITLE
add types-utils

### DIFF
--- a/packages/jsondiffpatch/src/types.ts
+++ b/packages/jsondiffpatch/src/types.ts
@@ -50,3 +50,43 @@ export interface Filter<TContext extends Context<any>> {
   (context: TContext): void;
   filterName: string;
 }
+
+export function isAddedDelta(delta: Delta): delta is AddedDelta {
+  return Array.isArray(delta) && delta.length === 1;
+}
+
+export function isModifiedDelta(delta: Delta): delta is ModifiedDelta {
+  return Array.isArray(delta) && delta.length === 2;
+}
+
+export function isDeletedDelta(delta: Delta): delta is DeletedDelta {
+  return (
+    Array.isArray(delta) &&
+    delta.length === 3 &&
+    delta[1] === 0 &&
+    delta[2] === 0
+  );
+}
+
+export function isObjectDelta(delta: Delta): delta is ObjectDelta {
+  return (
+    delta !== undefined && typeof delta === 'object' && !Array.isArray(delta)
+  );
+}
+
+export function isArrayDelta(delta: Delta): delta is ArrayDelta {
+  return (
+    delta !== undefined &&
+    typeof delta === 'object' &&
+    '_t' in delta &&
+    delta._t === 'a'
+  );
+}
+
+export function isMovedDelta(delta: Delta): delta is MovedDelta {
+  return Array.isArray(delta) && delta.length === 3 && delta[2] === 3;
+}
+
+export function isTextDiffDelta(delta: Delta): delta is TextDiffDelta {
+  return Array.isArray(delta) && delta.length === 3 && delta[2] === 2;
+}


### PR DESCRIPTION
Hello, while working with this library, I had to create several type utilities to help me identify deltas. I believe these could also be helpful to others using this library.

This pull request adds several type guard functions to the `packages/jsondiffpatch/src/types.ts` file. These functions are designed to help identify specific types of `Delta` objects, improving type safety and code readability.

New type guard functions:

* [`isAddedDelta`](diffhunk://#diff-96bbd6ee890fe390890bc0d986a1598331a36369ec2096a7fe4bc5c8b870eca2R53-R92): Checks if a `delta` is of type `AddedDelta`.
* [`isModifiedDelta`](diffhunk://#diff-96bbd6ee890fe390890bc0d986a1598331a36369ec2096a7fe4bc5c8b870eca2R53-R92): Checks if a `delta` is of type `ModifiedDelta`.
* [`isDeletedDelta`](diffhunk://#diff-96bbd6ee890fe390890bc0d986a1598331a36369ec2096a7fe4bc5c8b870eca2R53-R92): Checks if a `delta` is of type `DeletedDelta`.
* [`isObjectDelta`](diffhunk://#diff-96bbd6ee890fe390890bc0d986a1598331a36369ec2096a7fe4bc5c8b870eca2R53-R92): Checks if a `delta` is of type `ObjectDelta`.
* [`isArrayDelta`](diffhunk://#diff-96bbd6ee890fe390890bc0d986a1598331a36369ec2096a7fe4bc5c8b870eca2R53-R92): Checks if a `delta` is of type `ArrayDelta`.
* [`isMovedDelta`](diffhunk://#diff-96bbd6ee890fe390890bc0d986a1598331a36369ec2096a7fe4bc5c8b870eca2R53-R92): Checks if a `delta` is of type `MovedDelta`.
* [`isTextDiffDelta`](diffhunk://#diff-96bbd6ee890fe390890bc0d986a1598331a36369ec2096a7fe4bc5c8b870eca2R53-R92): Checks if a `delta` is of type `TextDiffDelta`.