### PR TITLE
fix: don't sort object keys, fix #267

### DIFF
--- a/packages/jsondiffpatch/src/formatters/base.ts
+++ b/packages/jsondiffpatch/src/formatters/base.ts
@@ -281,8 +281,6 @@ abstract class BaseFormatter<
     }
     if (arrayKeys) {
       keys.sort(arrayKeyComparer);
-    } else {
-      keys.sort();
     }
     for (let index = 0, length = keys.length; index < length; index++) {
       const key = keys[index];


### PR DESCRIPTION
object keys were being sorted alphabetically for all formatters. this seem like unintended behavior.
without the sort the order if preserved as: keys found in left object, followed by keys found *only* in right object.