### PR TITLE
feat: support extending JSONFormatter

### DIFF
--- a/packages/jsondiffpatch/src/formatters/jsonpatch.ts
+++ b/packages/jsondiffpatch/src/formatters/jsonpatch.ts
@@ -4,6 +4,7 @@ import type {
 	Delta,
 	ModifiedDelta,
 	ObjectDelta,
+	TextDiffDelta,
 } from "../types.js";
 import { applyJsonPatchRFC6902 } from "./jsonpatch-apply.js";
 
@@ -40,6 +41,13 @@ export interface MoveOp {
 export type Op = AddOp | RemoveOp | ReplaceOp | MoveOp;
 
 class JSONFormatter {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	protected processTextDiff(ops: Op[], path: string, diff: string) { // changed
+		throw new Error(
+			"JSONPatch (RFC 6902) doesn't support text diffs, disable textDiff option",
+		);
+	}
+
 	format(delta: Delta): Op[] {
 		const ops: Op[] = [];
 
@@ -75,9 +83,7 @@ class JSONFormatter {
 				}
 				// text diff
 				if (current.delta[2] === 2) {
-					throw new Error(
-						"JSONPatch (RFC 6902) doesn't support text diffs, disable textDiff option",
-					);
+					this.processTextDiff(ops, current.path, current.delta[0] as string);
 				}
 			} else if (current.delta._t === "a") {
 				// array delta
@@ -89,7 +95,7 @@ class JSONFormatter {
 				const inserts: { to: number; value: unknown }[] = [];
 				const updates: {
 					to: number;
-					delta: ObjectDelta | ArrayDelta | ModifiedDelta;
+					delta: ObjectDelta | ArrayDelta | ModifiedDelta | TextDiffDelta;
 				}[] = [];
 
 				for (const key of Object.keys(arrayDelta)) {
@@ -118,10 +124,8 @@ class JSONFormatter {
 							} else if (itemDelta.length === 2) {
 								updates.push({ to: index, delta: itemDelta });
 							} else if (itemDelta.length === 3) {
-								if (itemDelta[2] === 3) {
-									throw new Error(
-										"JSONPatch (RFC 6902) doesn't support text diffs, disable textDiff option",
-									);
+								if (itemDelta[2] === 2) {
+									updates.push({ to: index, delta: itemDelta });
 								}
 							}
 						}
@@ -193,6 +197,8 @@ class JSONFormatter {
 								path: `${current.path}/${to}`,
 								value: delta[1],
 							});
+						} else {
+							this.processTextDiff(ops, `${current.path}/${to}`, delta[0]);
 						}
 					} else {
 						// nested delta (object or array)


### PR DESCRIPTION
Support extending JSONFormatter with custom text diff operations, and fix a potential bug where MovedDelta is identified as a TextDiffDelta: 
```
  if (itemDelta[2] === 3) {
    throw new Error(
      "JSONPatch (RFC 6902) doesn't support text diffs, disable textDiff option",
    );
  }
```
As of now I have to make my own copy of JSONFormatter to extend it. By accepting this PR this would be a cleaner integration for me, and give other the same easy way of supporting custom text diffing operations by extending JSONFormatter like this:
```
class MyJSONFormatter extends JSONFormater {
  protected override processTextDiff(ops: Op[], path: string, diff: string) {
    const lines = parseTextDiff(diff);
    for (const line of lines) ...
  }
}
```

