### PR TITLE
fix(jsonpatch-apply): support JSON Patch add '/-' for array append 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3576,7 +3576,7 @@
 			}
 		},
 		"packages/diff-mcp": {
-			"version": "0.0.3",
+			"version": "0.0.4",
 			"license": "MIT",
 			"dependencies": {
 				"@dmsnell/diff-match-patch": "^1.1.0",

--- a/packages/jsondiffpatch/package.json
+++ b/packages/jsondiffpatch/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsondiffpatch",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"author": "Benjamin Eidelman <beneidel@gmail.com>",
 	"description": "JSON diff & patch (object and array diff, text diff, multiple output formats)",
 	"contributors": ["Benjamin Eidelman <beneidel@gmail.com>"],

--- a/packages/jsondiffpatch/test/formatters/jsonpatch.spec.ts
+++ b/packages/jsondiffpatch/test/formatters/jsonpatch.spec.ts
@@ -365,4 +365,27 @@ describe("jsonpatch", () => {
 			replaceOp("/tree~1item", 2),
 		]);
 	});
+
+	// RFC 6902 '-' index support (only for add)
+	describe("RFC6902 '-' index support", () => {
+		it("should append to end of array when using add with '-'", () => {
+			const before = { list: [1, 2, 3] };
+			const ops: jsonpatchFormatter.Op[] = [
+				{ op: "add", path: "/list/-", value: 4 },
+			];
+			const target = jsondiffpatch.clone(before);
+			formatter.patch(target, ops);
+			expect(target).toEqual({ list: [1, 2, 3, 4] });
+		});
+
+		it("should throw when using '-' in remove", () => {
+			const before = { list: [1, 2, 3] };
+			const ops: jsonpatchFormatter.Op[] = [
+				{ op: "remove", path: "/list/-" },
+			];
+			expect(() => formatter.patch(jsondiffpatch.clone(before), ops)).toThrow(
+				/JSONPatch 'remove' path cannot end with '-'/,
+			);
+		});
+	});
 });


### PR DESCRIPTION
This PR introduces support for the /- path syntax in the JSON Patch add operation, which allows for appending elements to the end of an array. This change aligns our implementation more closely with the behavior specified in RFC 6902 [Section 4.1](https://datatracker.ietf.org/doc/html/rfc6902#section-4.1) & [A.16](https://datatracker.ietf.org/doc/html/rfc6902#appendix-A.16). 

> If the "-" character is used to index the end of the array (see [[RFC6901](https://datatracker.ietf.org/doc/html/rfc6901)]), this has the effect of appending the value to the array.

Key Changes
Array Append with add:
The add operation now correctly interprets a path ending in /- as an instruction to append a value to the target array. For example, a patch like { "op": "add", "path": "/a/b/-", "value": "new" } will add "new" to the end of the array at /a/b.

Strict Path Validation:
The /- path suffix is a special case valid only for the add operation. This PR adds explicit checks to throw an error if a path ending in /- is used with any other operation, preventing incorrect behavior.

Fixed this issue: https://github.com/benjamine/jsondiffpatch/issues/434