### PR TITLE
fix: support RegExp flags added after es2017 (s, d, v) in clone and patch

### DIFF
--- a/packages/jsondiffpatch/src/clone.ts
+++ b/packages/jsondiffpatch/src/clone.ts
@@ -1,5 +1,5 @@
 function cloneRegExp(re: RegExp) {
-	const regexMatch = /^\/(.*)\/([gimyu]*)$/.exec(re.toString());
+	const regexMatch = /^\/(.*)\/([dgimsuvy]*)$/.exec(re.toString());
 	if (!regexMatch) {
 		throw new Error("Invalid RegExp");
 	}

--- a/packages/jsondiffpatch/src/filters/trivial.ts
+++ b/packages/jsondiffpatch/src/filters/trivial.ts
@@ -88,7 +88,7 @@ export const patchFilter: Filter<PatchContext> =
 		}
 		if (nonNestedDelta.length === 2) {
 			if (context.left instanceof RegExp) {
-				const regexArgs = /^\/(.*)\/([gimyu]+)$/.exec(
+				const regexArgs = /^\/(.*)\/([dgimsuvy]+)$/.exec(
 					nonNestedDelta[1] as string,
 				);
 				if (regexArgs?.[1]) {

--- a/packages/jsondiffpatch/test/examples/diffpatch.ts
+++ b/packages/jsondiffpatch/test/examples/diffpatch.ts
@@ -17,6 +17,11 @@ type ExampleGroup = Example[];
 
 const exampleDate = () => new Date(2020, 10, 30, 15, 10, 3);
 
+// Built via the constructor rather than a `/…/s` literal so these compile under
+// the repo's es6 target (the `s` flag postdates es6 and a literal would error).
+const regExpWithFlags = (source: string, flags: string) =>
+	new RegExp(source, flags);
+
 const atomicValues: ExampleGroup = [
 	// undefined
 	{
@@ -463,6 +468,13 @@ const atomicValues: ExampleGroup = [
 		right: /another regex/gi,
 		delta: ["/regex/g", "/another regex/gi"],
 		reverse: ["/another regex/gi", "/regex/g"],
+	},
+	{
+		name: "RegExp -> RegExp (dotAll flag)",
+		left: regExpWithFlags("regex", "s"),
+		right: regExpWithFlags("another regex", "s"),
+		delta: ["/regex/s", "/another regex/s"],
+		reverse: ["/another regex/s", "/regex/s"],
 	},
 
 	// object

--- a/packages/jsondiffpatch/test/index.spec.ts
+++ b/packages/jsondiffpatch/test/index.spec.ts
@@ -137,6 +137,16 @@ describe("DiffPatcher", () => {
 				pattern: /expr/gim,
 			});
 		});
+		it("clones RegExp with flags added after es2017 (s, d, v)", () => {
+			// `s` (es2018), `d` (es2022) and `v` (es2024) all postdate the repo's
+			// es6 target, so build via the constructor with a non-literal flag
+			// (a `/…/s` literal would not compile).
+			for (const flag of ["s", "d", "v"]) {
+				const pattern = new RegExp("expr", flag);
+				const cloned = jsondiffpatch.clone({ pattern });
+				expect(cloned).toEqual({ pattern });
+			}
+		});
 	});
 
 	describe("using cloneDiffValues", () => {


### PR DESCRIPTION
`cloneRegExp` in `clone.ts` and the trivial patch filter in `filters/trivial.ts` both rebuild a RegExp by re-parsing `RegExp.prototype.toString()` with a `[gimyu]` flag character class:

```js
/^\/(.*)\/([gimyu]*)$/.exec(re.toString())   // clone.ts
/^\/(.*)\/([gimyu]+)$/.exec(...)             // filters/trivial.ts (patch)
```

That class never picked up the flags the language added later: `s` (es2018), `d` (es2022) and `v` (es2024). `toString()` emits them fine, but the parser rejects them, so:

- `clone(/x/s)` throws `Invalid RegExp` (same for `/x/d` and `/x/v`). `clone` runs over values during diff/patch, so any object holding such a RegExp can't be diffed or patched at all.
- Round-tripping one through `diff` + `patch` drops it: the patch filter fails to match and falls through to returning the raw delta string instead of a RegExp.

Repro:

```js
jsondiffpatch.clone(/x/s);                 // throws "Invalid RegExp"

const d = jsondiffpatch.diff(/a/s, /b/s);  // ["/a/s", "/b/s"]
jsondiffpatch.patch(/a/s, d);              // "/b/s" (a string), not /b/s
```

Fix: widen both classes to `[dgimsuvy]` so every flag `toString()` can produce is accepted. Only the character class changes; the `*`/`+` quantifiers are left as they were.

Tests: a `RegExp -> RegExp (dotAll flag)` round-trip example plus a `clone` test covering `s`/`d`/`v`. Both are written with `new RegExp(...)` rather than `/…/s` literals because the package targets es6 and those literals don't compile there. The full suite passes; both new tests fail on `master`.
